### PR TITLE
[FIX] Fixed dependecy name on __manifest__.py

### DIFF
--- a/edi/__manifest__.py
+++ b/edi/__manifest__.py
@@ -18,7 +18,7 @@
         "base_edi",
         "component_event",
         "mail",
-        "base_sparse_field",
+        "base_sparse_field_list_support",
         "queue_job",
     ],
     "external_dependencies": {"python": ["pyyaml"]},


### PR DESCRIPTION
The right name is base_sparse_field_list_support because was rewrite in commit  a28bb05 in server-tools OCA's repo.